### PR TITLE
update python version from 3.8 to 3.11 in Notebook 4

### DIFF
--- a/04-sagemaker-project.ipynb
+++ b/04-sagemaker-project.ipynb
@@ -1078,7 +1078,7 @@
     "phases:\n",
     "  install:\n",
     "    runtime-versions:\n",
-    "      python: 3.8\n",
+    "      python: 3.11\n",
     "    commands:\n",
     "      - pip install --upgrade --force-reinstall . \"awscli>1.20.30\"\n",
     "  \n",


### PR DESCRIPTION
The lab 4 will give failure in CodeBuild:
Error messages:

7 | [Container] 2023/09/13 14:28:12 Processing environment variables
8 | [Container] 2023/09/13 14:28:12 Selecting 'python' runtime version '3.8' based on manual selections...
9 | [Container] 2023/09/13 14:28:12 Phase complete: DOWNLOAD_SOURCE State: FAILED
10 | [Container] 2023/09/13 14:28:12 Phase context status code: YAML_FILE_ERROR Message: Unknown runtime version named '3.8' of python. This build image has the following versions: 3.11

So I have update the notebook 04 for "codebuild-buildspec.yml".
I have tested that this is working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
