### PR TITLE
fix docker-compose command not found

### DIFF
--- a/00-start-here.ipynb
+++ b/00-start-here.ipynb
@@ -973,105 +973,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
-      "Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]\n",
-      "Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]\n",
-      "Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]\n",
-      "Get:5 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [3606 kB]\n",
-      "Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1526 kB]\n",
-      "Get:7 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [2911 kB]\n",
-      "Get:8 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1230 kB]\n",
-      "Get:9 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [2606 kB]\n",
-      "Get:10 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [3748 kB]\n",
-      "Get:11 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [35.2 kB]\n",
-      "Fetched 16.0 MB in 2s (9253 kB/s)\n",
-      "Reading package lists...\n",
-      "Reading package lists...\n",
-      "Building dependency tree...\n",
-      "Reading state information...\n",
-      "curl is already the newest version (7.81.0-1ubuntu1.20).\n",
-      "The following NEW packages will be installed:\n",
-      "  ca-certificates openssl\n",
-      "0 upgraded, 2 newly installed, 0 to remove and 25 not upgraded.\n",
-      "Need to get 1347 kB of archives.\n",
-      "After this operation, 2511 kB of additional disk space will be used.\n",
-      "Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openssl amd64 3.0.2-0ubuntu1.18 [1184 kB]\n",
-      "Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 ca-certificates all 20240203~22.04.1 [162 kB]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "debconf: delaying package configuration, since apt-utils is not installed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fetched 1347 kB in 0s (10.3 MB/s)\n",
-      "Selecting previously unselected package openssl.\n",
-      "(Reading database ... 13790 files and directories currently installed.)\n",
-      "Preparing to unpack .../openssl_3.0.2-0ubuntu1.18_amd64.deb ...\n",
-      "Unpacking openssl (3.0.2-0ubuntu1.18) ...\n",
-      "Selecting previously unselected package ca-certificates.\n",
-      "Preparing to unpack .../ca-certificates_20240203~22.04.1_all.deb ...\n",
-      "Unpacking ca-certificates (20240203~22.04.1) ...\n",
-      "Setting up openssl (3.0.2-0ubuntu1.18) ...\n",
-      "Setting up ca-certificates (20240203~22.04.1) ...\n",
-      "debconf: unable to initialize frontend: Dialog\n",
-      "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)\n",
-      "debconf: falling back to frontend: Readline\n",
-      "Updating certificates in /etc/ssl/certs...\n",
-      "rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL\n",
-      "146 added, 0 removed; done.\n",
-      "Processing triggers for ca-certificates (20240203~22.04.1) ...\n",
-      "Updating certificates in /etc/ssl/certs...\n",
-      "0 added, 0 removed; done.\n",
-      "Running hooks in /etc/ca-certificates/update.d...\n",
-      "done.\n",
-      "Get:1 https://download.docker.com/linux/ubuntu jammy InRelease [48.8 kB]\n",
+      "Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease\n",
       "Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease\n",
-      "Get:3 https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages [52.6 kB]\n",
-      "Hit:4 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
-      "Hit:5 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n",
-      "Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n",
-      "Fetched 101 kB in 0s (264 kB/s)\n",
+      "Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
+      "Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n",
+      "Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n",
       "Reading package lists...\n",
       "Reading package lists...\n",
       "Building dependency tree...\n",
       "Reading state information...\n",
-      "The following NEW packages will be installed:\n",
-      "  docker-ce-cli docker-compose-plugin\n",
-      "0 upgraded, 2 newly installed, 0 to remove and 25 not upgraded.\n",
-      "Need to get 56.0 MB of archives.\n",
-      "After this operation, 218 MB of additional disk space will be used.\n",
-      "Get:1 https://download.docker.com/linux/ubuntu jammy/stable amd64 docker-ce-cli amd64 5:20.10.24~3-0~ubuntu-jammy [43.2 MB]\n",
-      "Get:2 https://download.docker.com/linux/ubuntu jammy/stable amd64 docker-compose-plugin amd64 2.32.4-1~ubuntu.22.04~jammy [12.8 MB]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "debconf: delaying package configuration, since apt-utils is not installed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fetched 56.0 MB in 1s (109 MB/s)\n",
-      "Selecting previously unselected package docker-ce-cli.\n",
-      "(Reading database ... 14266 files and directories currently installed.)\n",
-      "Preparing to unpack .../docker-ce-cli_5%3a20.10.24~3-0~ubuntu-jammy_amd64.deb ...\n",
-      "Unpacking docker-ce-cli (5:20.10.24~3-0~ubuntu-jammy) ...\n",
-      "Selecting previously unselected package docker-compose-plugin.\n",
-      "Preparing to unpack .../docker-compose-plugin_2.32.4-1~ubuntu.22.04~jammy_amd64.deb ...\n",
-      "Unpacking docker-compose-plugin (2.32.4-1~ubuntu.22.04~jammy) ...\n",
-      "Setting up docker-compose-plugin (2.32.4-1~ubuntu.22.04~jammy) ...\n",
-      "Setting up docker-ce-cli (5:20.10.24~3-0~ubuntu-jammy) ...\n",
+      "ca-certificates is already the newest version (20240203~22.04.1).\n",
+      "curl is already the newest version (7.81.0-1ubuntu1.21).\n",
+      "0 upgraded, 0 newly installed, 0 to remove and 8 not upgraded.\n",
+      "Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease\n",
+      "Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
+      "Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n",
+      "Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n",
+      "Hit:5 http://security.ubuntu.com/ubuntu jammy-security InRelease\n",
+      "Reading package lists...\n",
+      "Reading package lists...\n",
+      "Building dependency tree...\n",
+      "Reading state information...\n",
+      "docker-ce-cli is already the newest version (5:20.10.24~3-0~ubuntu-jammy).\n",
+      "docker-compose-plugin is already the newest version (5.0.0-1~ubuntu.22.04~jammy).\n",
+      "0 upgraded, 0 newly installed, 0 to remove and 7 not upgraded.\n",
       "Client:\n",
       " Version:           unknown-version\n",
       " API version:       1.44 (downgraded from 1.47)\n",
@@ -1083,22 +1008,60 @@
       "\n",
       "Server:\n",
       " Engine:\n",
-      "  Version:          25.0.6\n",
+      "  Version:          25.0.13\n",
       "  API version:      1.44 (minimum version 1.24)\n",
-      "  Go version:       go1.22.5\n",
-      "  Git commit:       b08a51f\n",
-      "  Built:            Mon Jul 29 17:22:09 2024\n",
+      "  Go version:       go1.24.9\n",
+      "  Git commit:       165516e\n",
+      "  Built:            Mon Nov  3 00:00:00 2025\n",
       "  OS/Arch:          linux/amd64\n",
       "  Experimental:     false\n",
       " containerd:\n",
-      "  Version:          1.7.23\n",
-      "  GitCommit:        57f17b0a6295a39009d861b89e3b3b87b005ca27\n",
+      "  Version:          2.1.4\n",
+      "  GitCommit:        75cb2b7193e4e490e9fbdc236c0e811ccaba3376\n",
       " runc:\n",
-      "  Version:          1.2.4\n",
-      "  GitCommit:        6c52b3fc541fb26fe8c374d5f58112a0a5dbda66\n",
+      "  Version:          1.3.3\n",
+      "  GitCommit:        d842d7719497cc3b774fd71620278ac9e17710e0\n",
       " docker-init:\n",
       "  Version:          0.19.0\n",
-      "  GitCommit:        de40ad0\n"
+      "  GitCommit:        de40ad0\n",
+      "Docker Compose version v5.0.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  1418  100  1418    0     0  16687      0 --:--:-- --:--:-- --:--:-- 16880\n",
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n",
+      "100 2884k  100 2884k    0     0  11.5M      0 --:--:-- --:--:-- --:--:-- 77.0M\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/usr/bin/update-alternatives\n",
+      "Configuring docker-compose alternatives\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "update-alternatives: warning: forcing reinstallation of alternative /usr/local/bin/compose-switch because link group docker-compose is broken\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'docker-compose' is now set to run Compose V2\n",
+      "use 'update-alternatives --config docker-compose' if you want to switch back to Compose V1\n",
+      "Docker Compose version v5.0.0\n"
      ]
     }
    ],
@@ -1126,7 +1089,16 @@
     "sudo apt-get install docker-ce-cli=$VERSION_STRING docker-compose-plugin -y\n",
     "\n",
     "# validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]\n",
-    "docker version"
+    "docker version\n",
+    "# validate the Docker Compose plugin installed\n",
+    "docker compose version\n",
+    "\n",
+    "# Install Compose Switch. this is a replacement to the Compose V1 docker-compose (python) executable.\n",
+    "# It translates the command line into Compose V2 docker compose then run the latter.\n",
+    "# this is needed by the sagemaker python sdk to run in local mode\n",
+    "# see https://github.com/docker/compose-switch\n",
+    "curl -fL https://raw.githubusercontent.com/docker/compose-switch/master/install_on_linux.sh | sudo sh\n",
+    "docker-compose version"
    ]
   },
   {


### PR DESCRIPTION
*Issue #23 

*Description of changes:*
 install `compose-switch` from https://github.com/docker/compose-switch as part of a tempoarary fix until the sagemaker sdk supports the `docker compose` command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
